### PR TITLE
Check for nil Names before addressing slice

### DIFF
--- a/module/replace.go
+++ b/module/replace.go
@@ -75,6 +75,9 @@ func (v retag) Visit(n ast.Node) ast.Visitor {
 	}
 
 	if f, ok := n.(*ast.Field); ok {
+		if len(f.Names) == 0 {
+			return nil
+		}
 		newTags := v.tags[f.Names[0].String()]
 		if newTags == nil {
 			return nil


### PR DESCRIPTION
Fixes a index of of range error when using GRPC endpoints that return a stream