### PR TITLE
fix: opt module

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,5 +8,8 @@ import (
 )
 
 func main() {
-	pgs.Init(pgs.DebugEnv("GOTAG_DEBUG")).RegisterModule(module.New()).RegisterPostProcessor(pgsgo.GoFmt()).Render()
+	pgs.Init(pgs.DebugEnv("GOTAG_DEBUG")).
+		RegisterModule(module.New()).
+		RegisterPostProcessor(pgsgo.GoFmt()).
+		Render()
 }


### PR DESCRIPTION
When use `-go_out=. --go_opt=module=github.com/khorevaa/awesomeProject2` files not found

Add read option `module` for `--gotag_opt=module=github.com/khorevaa/awesomeProject2` and trim prefix from filename 