### PR TITLE
Updated to allow the optional field

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ retract v0.6.0
 
 require (
 	github.com/fatih/structtag v1.2.0
-	github.com/lyft/protoc-gen-star v0.5.3
+	github.com/lyft/protoc-gen-star v0.6.0
 	github.com/spf13/afero v1.5.1
 	golang.org/x/text v0.3.5 // indirect
 	google.golang.org/protobuf v1.26.0

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/lyft/protoc-gen-star v0.5.3 h1:zSGLzsUew8RT+ZKPHc3jnf8XLaVyHzTcAFBzHtCNR20=
 github.com/lyft/protoc-gen-star v0.5.3/go.mod h1:V0xaHgaf5oCCqmcxYcWiDfTiKsZsRc87/1qhoTACD8w=
+github.com/lyft/protoc-gen-star v0.6.0 h1:xOpFu4vwmIoUeUrRuAtdCrZZymT/6AkW/bsUWA506Fo=
+github.com/lyft/protoc-gen-star v0.6.0/go.mod h1:TGAoBVkt8w7MPG72TrKIu85MIdXwDuzJYeZuUPFPNwA=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/main.go
+++ b/main.go
@@ -3,12 +3,14 @@ package main
 import (
 	pgs "github.com/lyft/protoc-gen-star"
 	pgsgo "github.com/lyft/protoc-gen-star/lang/go"
+	"google.golang.org/protobuf/types/pluginpb"
 
 	"github.com/srikrsna/protoc-gen-gotag/module"
 )
 
 func main() {
-	pgs.Init(pgs.DebugEnv("GOTAG_DEBUG")).
+	supportedFeatures := uint64(pluginpb.CodeGeneratorResponse_FEATURE_PROTO3_OPTIONAL)
+	pgs.Init(pgs.DebugEnv("GOTAG_DEBUG"), pgs.SupportedFeatures(&supportedFeatures)).
 		RegisterModule(module.New()).
 		RegisterPostProcessor(pgsgo.GoFmt()).
 		Render()


### PR DESCRIPTION
- Updated `protoc-gen-star` to [v0.6.0](https://github.com/lyft/protoc-gen-star/releases/tag/v0.6.0)
- Added the `InitOption` to support optional fields (I'm not sure if this is the current best way to enable it, looking at [this commit](https://github.com/lyft/protoc-gen-star/pull/95/commits/69f0811692de0fa02fa8677f421c3ed56cd208c5#diff-d3d9c74492118533a3eb8c47d9923d33f007994ac87d47ecbe6ca95d8281131eL37), but it works fine)