### PR TITLE
fix protoc-gen-gotag in bsr by updating its googleapi dependency

### DIFF
--- a/buf.lock
+++ b/buf.lock
@@ -4,7 +4,4 @@ deps:
   - remote: buf.build
     owner: googleapis
     repository: googleapis
-    branch: main
-    commit: f503ec6637504fc3be424ad20a5a4225
-    digest: b1-H6-yP4btx2JVxeprkUCgnTk-2k1oFPPM1nVOF2VvOZE=
-    create_time: 2022-02-10T15:11:03.060619Z
+    commit: 62f35d8aed1149c291d606d958a7ce32


### PR DESCRIPTION
> You may need to upgrade your googleapis/googleapis dependency.
https:[//github.com/googleapis/googleapis](https://bufbuild.slack.com//github.com/googleapis/googleapis) contains over 3800 files, mostly
relating to Google's core APIs. However, there are only ~30 files used by
99.999%% of developers, and these files are the most common dependency in
the Protobuf ecosystem. This hosted module now only includes these specific
files, as including all the files causes hundreds of megabytes of unused
generated code for the vast majority of developers.
Before taking the BSR out of beta, we slimmed down googleapis from the ~3800
files to these common ~30 files. Having all ~3800 files caused many
issues for our consumers, with no benefit. Considering this, we made the
decision to trim down the module so we can ensure the best experience for our
users as we finalize v1.
At Buf, we take breaking changes incredibly seriously. This was done to ensure
the stability of the BSR as we move out of beta. We will never break consumers
after v1.
We apologize for any disruption this may cause, however we felt this
issue was serious enough to make this change prior to finalizing the BSR beta.
The mitigation for you is likely just to run:
buf mod update
This will bring you to the most recent commit of the updated googleapis module.
If you've pinned your googleapis dependency, you'll need to remove the pin and
update to a new pin with a reference from
https://buf.build/googleapis/googleapis.