### PR TITLE
Feature to auto add custom tag options to generated go structs

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,19 @@ Supported transformers:
 | "dot_notation", "dot", "lower_dot_notation", "lower_dot" | Make lower cased dot notation key | someKey -> some.key |
 | "upper_dot", "upper_dot_notation"                        | Make upper cased dot notation key | someKey -> Some.Key | 
 
+## Auto add tag options on field
+
+Automatically add custom tag options to message fields along with tag values.
+NOTE: "auto" parameter also needs to be specified for this particular feature to work
+
+```bash
+    protoc -I /usr/local/include \
+    	-I . \
+    	--gotag_out=auto="form+db-as-camel":. --gotag_opt=suffix="form:required+optional|db:omitempty" example/example.proto
+```
+
+The above command will add two tag options required,optional to form tag and omitempty tag option to db tag.
+
 ## Add tags to XXX* fields
 
 It is very useful to ignore XXX* fields in protobuf generated messages. The go protocol buffer compiler adds ```json:"-"``` tag to all XXX* fields. Additional tags can be added to these fields using the 'xxx' option of PGGT. It can be done like this. All '+' characters will be replaced with ':'.

--- a/module/tagger.go
+++ b/module/tagger.go
@@ -46,9 +46,17 @@ func (m mod) Execute(targets map[string]pgs.File, packages map[string]pgs.Packag
 		autoTags = strings.Split(autoTag, "+")
 	}
 
+	// To auto add struct tag options
+	// input will be of form eg: suffix="db:omitempty+required|graph:optional"
+	tagOptions := m.Parameters().Str("suffix")
+	var autoTagOptions []string
+	if tagOptions != "" {
+		autoTagOptions = strings.Split(tagOptions, "|")
+	}
+
 	module := m.Parameters().Str("module")
 
-	extractor := newTagExtractor(m, m.Context, autoTags)
+	extractor := newTagExtractor(m, m.Context, autoTags, autoTagOptions)
 
 	for _, f := range targets {
 		tags := extractor.Extract(f)


### PR DESCRIPTION
The following command will auto add provided custom tag options to generated go structs

```
protoc -I /usr/local/include \
    	-I . \
    	--gotag_out=auto="form-as-camel":. --gotag_opt=suffix="form:optional+required" example/example.proto
  

Generated Go struct
  
type Foo struct {
	Id   string `form:"id,optional,required"`
	Name string `form:"name,optional,required"`
	Age  int    `form:"age,optional,required"`
}
```	

resolution for the following issue https://github.com/srikrsna/protoc-gen-gotag/issues/41#issue-1824809599